### PR TITLE
fix: use `nuxt-edge` instead of `nuxt`

### DIFF
--- a/template/test/module.test.js
+++ b/template/test/module.test.js
@@ -1,4 +1,4 @@
-const { Nuxt, Builder } = require('nuxt')
+const { Nuxt, Builder } = require('nuxt-edge')
 const request = require('request-promise-native')
 
 const config = require('../example/nuxt.config')


### PR DESCRIPTION
Module `nuxt` not found.

```js
const { Nuxt, Builder } = require('nuxt')
```

In `package.json` is `nuxt-edge`
```js
const { Nuxt, Builder } = require('nuxt-edge')
```