### PR TITLE
chore: add package meta

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -13,4 +13,4 @@ export default /* async */ function (moduleOptions) {
 
 const DEFAULTS = {}
 
-export const meta = require('../package.json')
+module.exports.meta = require('../package.json')

--- a/lib/module.js
+++ b/lib/module.js
@@ -12,3 +12,5 @@ export default /* async */ function (moduleOptions) {
 }
 
 const DEFAULTS = {}
+
+export const meta = require('../package.json')

--- a/lib/module.js
+++ b/lib/module.js
@@ -13,4 +13,4 @@ export default /* async */ function (moduleOptions) {
 
 const DEFAULTS = {}
 
-module.exports.meta = require('../package.json')
+;(nuxtModule as any).meta = require('../package.json')

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "keywords": [
     "nuxt",
     "module",
-    "nuxt-module",
-    "typescript",
-    "javascript"
+    "nuxt-module"
   ],
   "repository": "github_repo",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,19 @@
   "name": "npm_package",
   "version": "0.0.0",
   "description": "",
+  "keywords": [
+    "nuxt",
+    "module",
+    "nuxt-module",
+    "typescript",
+    "javascript"
+  ],
   "repository": "github_repo",
   "license": "MIT",
+  "main": "lib/module.js",
   "files": [
     "lib"
   ],
-  "main": "lib/module.js",
   "scripts": {
     "dev": "nuxt example",
     "lint": "eslint --ext .js,.vue .",


### PR DESCRIPTION
This PR:
* adds meta keywords to `package.json` for use on package registry
* exposes `pkg.meta` in module export [as required](https://nuxtjs.org/guide/modules#write-a-basic-module)