### PR TITLE
docs: update Create a Nuxt Module instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Make sure to use a version of vue-cli >= 2.1 (vue -V) is installed.
 If you don't already have it, just install it.
 
 ```bash
-npx vue-cli init nuxt-community/module-template <module-name>
+npx @vue/cli init nuxt-community/module-template <module-name>
 cd <module-name>
 yarn install # or npm install
 ```


### PR DESCRIPTION
vue-cli isn't available anymore for npx